### PR TITLE
[multiple series] Fix case when series are already sorted

### DIFF
--- a/lib/rorschart/data/multiple_series.rb
+++ b/lib/rorschart/data/multiple_series.rb
@@ -32,13 +32,19 @@ module Rorschart
       # The Merge:
       # For abscisse value, grab for each serie the corresponding row - or nil
       union_series = []
+      asc = true
       union_x.each { |x|
         row = [x]
         series_indexed.each { |serie_hash|
           row << serie_hash[x]
+          asc = asc && ascending?(serie_hash)
         }
         union_series << row.flatten
       }
+
+      if !asc
+        union_series = union_series.reverse
+      end
 
       # Return union of all series
       union_series
@@ -62,6 +68,10 @@ module Rorschart
       }
 
       serie_hash
+    end
+
+    def ascending? hsh
+      hsh.keys == hsh.keys.sort
     end
 
   end

--- a/lib/rorschart/version.rb
+++ b/lib/rorschart/version.rb
@@ -1,3 +1,3 @@
 module Rorschart
-  VERSION = "0.19.0"
+  VERSION = "0.19.1"
 end


### PR DESCRIPTION
Fixes #9 : Prevents ascending order when series are already sorted in descending order